### PR TITLE
Break out config into separate file + remove references to secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ composer.lock
 xdebug
 vendor
 .idea
+config.PRIVATE.php

--- a/config.php
+++ b/config.php
@@ -1,0 +1,6 @@
+<?php
+return (object) array(
+	'token' => 'INSERT API TOKEN HERE',
+	'playername' => 'ryanmorris'
+);
+?>

--- a/index.php
+++ b/index.php
@@ -11,14 +11,18 @@ use BattleriteAPIToken\BattleriteAPIToken;
 /*$webToken->setToken('set token.');*/ // If you want to set a key manually.
 /*var_dump($webToken);*/
 
-$webAPI = new BattleriteWebApi(BattleriteAPIToken::init());
+$config = include('config.php');
+$token = BattleriteAPIToken::init();
+$token->setToken($config->token);
+$webAPI = new BattleriteWebApi($token);
 
 $webAPI->getFullStatus();
 /*echo $webAPI->getReleasedAt();
 echo "<br/> <br/> " . $webAPI->getVersion();*/
 
 /*echo "<br/> <br/> " . $webAPI->getRandomMatch('');*/
-$webAPI->getPlayerByName(['ryanmorris']);
+$playerName = $config->playername;
+$webAPI->getPlayerByName([$playerName]);
 
 echo "<br/> <br/>";
 

--- a/src/api/BattleriteAPIToken.php
+++ b/src/api/BattleriteAPIToken.php
@@ -8,7 +8,7 @@ class BattleriteAPIToken
      * API Token given for the Battlerite API
      * @var string
      */
-    public $token = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJjZWQ4MDJjMC1iYWYwLTAxMzUtODI4NC0wYTU4NjQ2MGE3NDUiLCJpc3MiOiJnYW1lbG9ja2VyIiwiaWF0IjoxNTEyMzcxNzE5LCJwdWIiOiJzdHVubG9jay1zdHVkaW9zIiwidGl0bGUiOiJiYXR0bGVyaXRlIiwiYXBwIjoiYmFwaXJpdGUiLCJzY29wZSI6ImNvbW11bml0eSIsImxpbWl0IjoxMH0.6irEd8QFHqBXUQmi7g9BSpS5MaaJWK1Q2W4useSU944';
+    public $token = '';
 
     /**
      * Static variable for the token with the API

--- a/test/src/api/BattleriteAPITokenTest.php
+++ b/test/src/api/BattleriteAPITokenTest.php
@@ -41,7 +41,7 @@ final class BattleriteAPITokenTest extends \PHPUnit_Framework_TestCase
     {
         /*$pages = new BattleriteAPIToken();
 
-        $expected = $pages->setToken('eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJjZWQ4MDJjMC1iYWYwLTAxMzUtODI4NC0wYTU4NjQ2MGE3NDUiLCJpc3MiOiJnYW1lbG9ja2VyIiwiaWF0IjoxNTEyMzcxNzE5LCJwdWIiOiJzdHVubG9jay1zdHVkaW9zIiwidGl0bGUiOiJiYXR0bGVyaXRlIiwiYXBwIjoiYmFwaXJpdGUiLCJzY29wZSI6ImNvbW11bml0eSIsImxpbWl0IjoxMH0.6irEd8QFHqBXUQmi7g9BSpS5MaaJWK1Q2W4useSU944');
+        $expected = $pages->setToken('abc');
 
         $this->assertEquals($expected, BattleriteAPIToken::init());*/
     }


### PR DESCRIPTION
I don't think that disclosing your api token is a big deal in this case, but it is something to think about in the future (with a more sensitive token).